### PR TITLE
Auto-fill university location

### DIFF
--- a/app/(candidates)/candidates/candidate-dashboard/my-profile/page.tsx
+++ b/app/(candidates)/candidates/candidate-dashboard/my-profile/page.tsx
@@ -5,7 +5,7 @@ import { PhotoUploader } from "@/components/ProfilePhotoUploader";
 import { useAuth } from "@clerk/nextjs";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Eye, Terminal } from "lucide-react";
+import { Terminal } from "lucide-react";
 import BasicProfileForm from "./BasicProfileForm";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,8 +19,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import Link from "next/link";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import TourModal from "@/components/tour/TourModal";
 import { usePageTitle } from "@/lib/usePageTitle";
 import EducationAdder from "@/components/EducationAdder";
@@ -28,7 +27,6 @@ import { extractEducation } from "@/lib/education";
 
 export default function BioSettingsPage() {
   usePageTitle("Candidate Dashboard – Profile");
-  const searchParams = useSearchParams();
   const router = useRouter();
   const { userId } = useAuth();
   const { data: candidateData, error, isLoading, refresh } = useCandidate();
@@ -178,8 +176,6 @@ function EducationList({
   const [graduationYear, setGraduationYear] = useState("");
   const [activities, setActivities] = useState("");
   const [website, setWebsite] = useState("");
-  const [editCity, setEditCity] = useState("");
-  const [editState, setEditState] = useState("");
   const [saving, setSaving] = useState(false);
 
   function openEdit(i: number) {
@@ -189,8 +185,6 @@ function EducationList({
     setGraduationYear(item.graduationYear ?? "");
     setActivities(item.activities ?? "");
     setWebsite(item.website ?? "");
-  setEditCity(item.city ?? "");
-  setEditState(item.state ?? "");
   }
 
   async function saveEdit() {
@@ -205,8 +199,8 @@ function EducationList({
           name: current.name,
           country: current.country,
           stateProvince: current.stateProvince ?? null,
-          city: editCity || null,
-          state: editState || null,
+          city: current.city ?? null,
+          state: current.state ?? null,
           website: website || null,
           degree: degree || null,
           graduationYear: graduationYear || null,

--- a/components/EducationAdder.tsx
+++ b/components/EducationAdder.tsx
@@ -27,6 +27,7 @@ export default function EducationAdder({
   const [degree, setDegree] = useState("");
   const [graduationYear, setGraduationYear] = useState("");
   const [activities, setActivities] = useState("");
+  // City and state are now auto-populated from the selected university
   const [city, setCity] = useState("");
   const [stateStr, setStateStr] = useState("");
   const [saving, setSaving] = useState(false);
@@ -37,7 +38,7 @@ export default function EducationAdder({
     setSaving(true);
     setMessage(null);
     const website = selected.web_pages?.[0] ?? null;
-  const stateProvince = (selected as any)["state-province"] ?? null;
+    const stateProvince = selected["state-province"] ?? null;
     try {
       const res = await fetch("/api/candidate/education", {
         method: "POST",
@@ -98,8 +99,11 @@ export default function EducationAdder({
               <UniversitySearch
                 onSelect={(u) => {
                   setSelected(u);
-                  const sp = (u as any)["state-province"] ?? "";
-                  if (sp) setStateStr(sp);
+                  // Automatically populate city and state from the API
+                  const stateVal = u.state ?? u["state-province"] ?? "";
+                  const cityVal = u.city ?? "";
+                  setStateStr(stateVal);
+                  setCity(cityVal);
                 }}
               />
             </div>
@@ -107,6 +111,11 @@ export default function EducationAdder({
             <div className="space-y-4">
               <div className="p-3 border rounded-md">
                 <div className="font-medium">{selected.name}</div>
+                {(city || stateStr) && (
+                  <div className="text-sm text-muted-foreground">
+                    {[city, stateStr].filter(Boolean).join(", ")}
+                  </div>
+                )}
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div className="space-y-1.5">
@@ -132,28 +141,6 @@ export default function EducationAdder({
                       setGraduationYear(e.target.value)
                     }
                     placeholder="e.g., 2024"
-                    className="w-full"
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="city">City</Label>
-                  <Input
-                    id="city"
-                    value={city}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCity(e.target.value)}
-                    placeholder="e.g., Cambridge"
-                    className="w-[90%]"
-                  />
-                </div>
-                <div className="space-y-1.5 ">
-                  <Label htmlFor="state">State/Region</Label>
-                  <Input
-                    id="state"
-                    value={stateStr}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setStateStr(e.target.value)}
-                    placeholder="e.g., MA"
                     className="w-full"
                   />
                 </div>

--- a/lib/universities.ts
+++ b/lib/universities.ts
@@ -6,6 +6,10 @@ export type University = {
   country: string;
   alpha_two_code?: string;
   "state-province"?: string | null;
+  /** City where the university is located, if provided by the API */
+  city?: string | null;
+  /** State or region abbreviation, if provided directly by the API */
+  state?: string | null;
   domains?: string[];
   web_pages?: string[];
 };
@@ -46,11 +50,16 @@ export async function fetchUniversities({
   }
 
   const data = (await res.json()) as University[];
-  // Basic normalization to ensure optional arrays exist
+  // Basic normalization to ensure optional arrays exist and to surface
+  // location details when the upstream API provides them.
   return data.map((u) => ({
     ...u,
     domains: u.domains ?? [],
     web_pages: u.web_pages ?? [],
+    // Some providers may expose `state` directly in addition to
+    // `state-province`; fall back accordingly.
+    state: u.state ?? u["state-province"] ?? null,
+    city: u.city ?? null,
     "state-province": u["state-province"] ?? null,
   }));
 }


### PR DESCRIPTION
## Summary
- auto-fill city and state in education adder using API data
- add city and state fields to university API wrapper
- remove manual city/state editing from profile education list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68bbedefc844832aa893ea2195b8dd83