### PR TITLE
Prioritize verified candidates in viewer suggestions

### DIFF
--- a/app/(voters)/candidate/[slug]/CandidateClient.tsx
+++ b/app/(voters)/candidate/[slug]/CandidateClient.tsx
@@ -84,18 +84,13 @@ export default function CandidateClient({
 
   const randomSuggestedCandidates = useMemo(() => {
     const verified: Candidate[] = [];
-    const unverified: Candidate[] = [];
     for (const c of suggestedCandidates) {
       if (c.id === candidate.id) continue;
       if (c.verified) {
         verified.push(c);
-      } else {
-        unverified.push(c);
       }
     }
-    const shuffledVerified = fisherYates(verified);
-    const shuffledUnverified = fisherYates(unverified);
-    return [...shuffledVerified, ...shuffledUnverified].slice(0, 3);
+    return fisherYates(verified).slice(0, 3);
   }, [candidate.id, suggestedCandidates]);
 
   useEffect(() => {

--- a/app/(voters)/candidate/[slug]/CandidateClient.tsx
+++ b/app/(voters)/candidate/[slug]/CandidateClient.tsx
@@ -84,13 +84,18 @@ export default function CandidateClient({
 
   const randomSuggestedCandidates = useMemo(() => {
     const verified: Candidate[] = [];
+    const unverified: Candidate[] = [];
     for (const c of suggestedCandidates) {
       if (c.id === candidate.id) continue;
       if (c.verified) {
         verified.push(c);
+      } else {
+        unverified.push(c);
       }
     }
-    return fisherYates(verified).slice(0, 3);
+    const shuffledVerified = fisherYates(verified);
+    const shuffledUnverified = fisherYates(unverified);
+    return [...shuffledVerified, ...shuffledUnverified].slice(0, 3);
   }, [candidate.id, suggestedCandidates]);
 
   useEffect(() => {

--- a/app/(voters)/candidate/[slug]/CandidateClient.tsx
+++ b/app/(voters)/candidate/[slug]/CandidateClient.tsx
@@ -74,8 +74,11 @@ export default function CandidateClient({
   );
 
   const randomSuggestedCandidates = useMemo(() => {
-    const shuffled = [...suggestedCandidates].sort(() => 0.5 - Math.random());
-    return shuffled.slice(0, 3);
+    const verified = suggestedCandidates.filter((c) => c.verified);
+    const unverified = suggestedCandidates.filter((c) => !c.verified);
+    const shuffledVerified = [...verified].sort(() => 0.5 - Math.random());
+    const shuffledUnverified = [...unverified].sort(() => 0.5 - Math.random());
+    return [...shuffledVerified, ...shuffledUnverified].slice(0, 3);
   }, [suggestedCandidates]);
 
   useEffect(() => {

--- a/app/(voters)/candidate/[slug]/CandidateClient.tsx
+++ b/app/(voters)/candidate/[slug]/CandidateClient.tsx
@@ -20,6 +20,15 @@ import { useUser } from "@clerk/nextjs";
 import ImageWithFallback from "@/components/ui/ImageWithFallback";
 import { decodeEducation } from "@/lib/education";
 
+function fisherYates<T>(arr: T[]): T[] {
+  const array = [...arr];
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
 export type ElectionWithCandidates = Election & {
   candidates: Candidate[];
 };
@@ -74,12 +83,20 @@ export default function CandidateClient({
   );
 
   const randomSuggestedCandidates = useMemo(() => {
-    const verified = suggestedCandidates.filter((c) => c.verified);
-    const unverified = suggestedCandidates.filter((c) => !c.verified);
-    const shuffledVerified = [...verified].sort(() => 0.5 - Math.random());
-    const shuffledUnverified = [...unverified].sort(() => 0.5 - Math.random());
+    const verified: Candidate[] = [];
+    const unverified: Candidate[] = [];
+    for (const c of suggestedCandidates) {
+      if (c.id === candidate.id) continue;
+      if (c.verified) {
+        verified.push(c);
+      } else {
+        unverified.push(c);
+      }
+    }
+    const shuffledVerified = fisherYates(verified);
+    const shuffledUnverified = fisherYates(unverified);
     return [...shuffledVerified, ...shuffledUnverified].slice(0, 3);
-  }, [suggestedCandidates]);
+  }, [candidate.id, suggestedCandidates]);
 
   useEffect(() => {
     setHydrated(true);

--- a/app/(voters)/candidate/[slug]/page.tsx
+++ b/app/(voters)/candidate/[slug]/page.tsx
@@ -155,6 +155,7 @@ export default async function CandidatePage({
     where: {
       id: { not: candidateID },
       hidden: false,
+      verified: true,
       elections: {
         some: {
           election: { type: ElectionType.LOCAL },

--- a/app/(voters)/candidate/[slug]/page.tsx
+++ b/app/(voters)/candidate/[slug]/page.tsx
@@ -150,8 +150,8 @@ export default async function CandidatePage({
     },
   });
 
-  // Get suggested candidates (only those with actual images)
-  const suggestedCandidatesRaw = await prisma.candidate.findMany({
+  // Get suggested candidates, excluding Cornell-affiliated profiles
+  const suggestedCandidates = await prisma.candidate.findMany({
     where: {
       id: { not: candidateID },
       hidden: false,
@@ -160,18 +160,23 @@ export default async function CandidatePage({
           election: { type: ElectionType.LOCAL },
         },
       },
-      NOT: [
-        { name: { contains: "Cornell", mode: "insensitive" } },
-        { currentRole: { contains: "Cornell", mode: "insensitive" } },
-        { bio: { contains: "Cornell", mode: "insensitive" } },
+      AND: [
+        {
+          name: {
+            not: { contains: "Cornell", mode: "insensitive" },
+          },
+        },
+        {
+          currentRole: {
+            not: { contains: "Cornell", mode: "insensitive" },
+          },
+        },
+        {
+          bio: { not: { contains: "Cornell", mode: "insensitive" } },
+        },
       ],
     },
   });
-  const suggestedCandidates = suggestedCandidatesRaw.filter(
-    (c) =>
-      (c.photo && c.photo.trim() !== "") ||
-      (c.photoUrl && c.photoUrl.trim() !== "")
-  );
 
   // Check if current user can edit this candidate profile
   const user = await currentUser();

--- a/app/(voters)/candidate/[slug]/page.tsx
+++ b/app/(voters)/candidate/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { headers } from "next/headers";
 import prisma from "@/prisma/prisma";
 import CandidateClient from "./CandidateClient";
-import { Candidate } from "@prisma/client";
+import { Candidate, ElectionType } from "@prisma/client";
 import { currentUser } from "@clerk/nextjs/server";
 import type { Metadata } from "next";
 
@@ -155,6 +155,11 @@ export default async function CandidatePage({
     where: {
       id: { not: candidateID },
       hidden: false,
+      elections: {
+        some: {
+          election: { type: ElectionType.LOCAL },
+        },
+      },
     },
   });
   const suggestedCandidates = suggestedCandidatesRaw.filter(

--- a/app/(voters)/candidate/[slug]/page.tsx
+++ b/app/(voters)/candidate/[slug]/page.tsx
@@ -155,7 +155,6 @@ export default async function CandidatePage({
     where: {
       id: { not: candidateID },
       hidden: false,
-      verified: true,
       elections: {
         some: {
           election: { type: ElectionType.LOCAL },

--- a/app/(voters)/candidate/[slug]/page.tsx
+++ b/app/(voters)/candidate/[slug]/page.tsx
@@ -160,6 +160,11 @@ export default async function CandidatePage({
           election: { type: ElectionType.LOCAL },
         },
       },
+      NOT: [
+        { name: { contains: "Cornell", mode: "insensitive" } },
+        { currentRole: { contains: "Cornell", mode: "insensitive" } },
+        { bio: { contains: "Cornell", mode: "insensitive" } },
+      ],
     },
   });
   const suggestedCandidates = suggestedCandidatesRaw.filter(


### PR DESCRIPTION
## Summary
- prioritize verified candidates when showing 'people who viewed {candidate} also viewed'

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6f3d67cc0832a84a3e6b459d309b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suggested candidates now exclude the currently viewed profile and prioritize verified candidates (up to three).
  * Suggestions are limited to candidates tied to local elections.
  * If fewer than three verified local candidates are available, suggestions are supplemented with unverified local candidates.
  * Improved randomness in suggestion ordering to provide varied recommendations without altering original data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->