### PR TITLE
sending summary email

### DIFF
--- a/app/(api)/api/admin/candidate-outreach/route.ts
+++ b/app/(api)/api/admin/candidate-outreach/route.ts
@@ -3,6 +3,7 @@ import {
   sendBatchWithResend,
   SendEmailParams,
   isEmailDryRun,
+  sendWithResend
 } from "@/lib/email/resend";
 import { renderEmailTemplate, TemplateKey } from "@/lib/email/templates/render";
 
@@ -286,14 +287,14 @@ export async function POST(req: NextRequest) {
 
       const sentAtIso = new Date().toISOString();
       try{
-        await sendBatchWithResend([
+        await sendWithResend(
         {
           to: "team@elevracommunity.com",
           subject: `[Outreach] ${step.template} summary (${batchResult.successes.length}/${recipients.length}) • ${sentAtIso}`,
           html: summaryHtml,
           from: body.from,
         }
-        ]);
+        );
       }catch(err){
         console.error("Error sending summary email:", err);
       }

--- a/app/(api)/api/admin/candidate-outreach/route.ts
+++ b/app/(api)/api/admin/candidate-outreach/route.ts
@@ -285,14 +285,18 @@ export async function POST(req: NextRequest) {
       `;
 
       const sentAtIso = new Date().toISOString();
-      await sendBatchWithResend([
+      try{
+        await sendBatchWithResend([
         {
           to: "team@elevracommunity.com",
           subject: `[Outreach] ${step.template} summary (${batchResult.successes.length}/${recipients.length}) • ${sentAtIso}`,
           html: summaryHtml,
           from: body.from,
         }
-      ]);
+        ]);
+      }catch(err){
+        console.error("Error sending summary email:", err);
+      }
     }
   }
 


### PR DESCRIPTION
This code adds another sendBatchWithResend that'll provide a structured summary of the Outreach emails sent. ChatGPT structured the summary w/ HTML: type of "step" (initial, followUp, verifiedUpdate, etc), number of successes and failures, etc). The email sent also provides the ISO date at the time of sending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * After each non–dry-run outreach batch with at least one success, the system sends a single HTML+plain-text summary email to team@elevracommunity.com. The summary includes template used, schedule overview, totals, counts of successes/failures/invalid rows, and detailed lists of failures and invalid entries; email send errors are handled so they don't block processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->