### PR TITLE
Fix election tab content visibility logic

### DIFF
--- a/lib/content-blocks.ts
+++ b/lib/content-blocks.ts
@@ -1,8 +1,37 @@
-import { ContentBlock } from "@prisma/client";
+import { BlockType, ContentBlock } from "@prisma/client";
 
-export const unchanged = (b: ContentBlock) => {
-  const createdAtDate = new Date(b.createdAt);
-  const updatedAtDate = new Date(b.updatedAt);
+function hasMeaningfulContent(block: ContentBlock): boolean {
+  switch (block.type) {
+    case BlockType.HEADING:
+      return Boolean(block.text?.trim());
+    case BlockType.TEXT:
+      return Boolean(block.body?.trim());
+    case BlockType.LIST:
+      return (block.items ?? []).some((item) => Boolean(item?.trim()));
+    case BlockType.IMAGE:
+      return Boolean(block.imageUrl || block.caption?.trim());
+    case BlockType.VIDEO:
+      return Boolean(
+        block.videoUrl || block.thumbnailUrl || block.caption?.trim()
+      );
+    case BlockType.DIVIDER:
+      return true;
+    default:
+      return false;
+  }
+}
 
-  return createdAtDate.getTime() === updatedAtDate.getTime();
+export const unchanged = (block: ContentBlock) => {
+  const createdAt = new Date(block.createdAt);
+  const updatedAt = new Date(block.updatedAt);
+
+  if (
+    Number.isNaN(createdAt.getTime()) ||
+    Number.isNaN(updatedAt.getTime()) ||
+    createdAt.getTime() !== updatedAt.getTime()
+  ) {
+    return false;
+  }
+
+  return !hasMeaningfulContent(block);
 };


### PR DESCRIPTION
## Summary
- update the content block unchanged helper to inspect block content instead of only timestamps
- ensure public election tabs show blocks that contain real data while still hiding empty placeholders

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9bf5c40dc832a8e146c5b31d1e8ca