### PR TITLE
Align live election ordering with suggested candidates

### DIFF
--- a/app/(api)/api/suggested-candidates/route.ts
+++ b/app/(api)/api/suggested-candidates/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import prisma from "@/prisma/prisma";
+import {
+  buildSuggestedCandidateWhere,
+  suggestedCandidateOrderBy,
+} from "@/lib/suggestedCandidates";
+
+export async function GET() {
+  try {
+    const candidates = await prisma.candidate.findMany({
+      where: buildSuggestedCandidateWhere(),
+      orderBy: suggestedCandidateOrderBy,
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        verified: true,
+        currentRole: true,
+        photo: true,
+        clerkUserId: true,
+        elections: {
+          select: {
+            election: {
+              select: {
+                id: true,
+                city: true,
+                state: true,
+                date: true,
+                position: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(candidates);
+  } catch (error) {
+    console.error("Error fetching suggested candidates:", error);
+    return NextResponse.json(
+      { error: "Error fetching suggested candidates" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/(voters)/candidate/[slug]/page.tsx
+++ b/app/(voters)/candidate/[slug]/page.tsx
@@ -2,6 +2,10 @@ export const dynamic = "force-dynamic";
 import { notFound } from "next/navigation";
 import { headers } from "next/headers";
 import prisma from "@/prisma/prisma";
+import {
+  buildSuggestedCandidateWhere,
+  suggestedCandidateOrderBy,
+} from "@/lib/suggestedCandidates";
 import CandidateClient from "./CandidateClient";
 import { Candidate } from "@prisma/client";
 import { currentUser } from "@clerk/nextjs/server";
@@ -168,23 +172,8 @@ export default async function CandidatePage({
 
   // Suggested list prioritizes candidates with real image content blocks
   const suggestedCandidates = await prisma.candidate.findMany({
-    where: {
-      id: { not: candidateID },
-      hidden: false,
-      elections: {
-        some: {
-          ContentBlock: {
-            some: {
-              type: "IMAGE",
-              imageUrl: {
-                notIn: ["/example-johnny.jpg", "/johnny-lawnsign.png"],
-                not: null,
-              },
-            },
-          },
-        },
-      },
-    },
+    where: buildSuggestedCandidateWhere(candidateID),
+    orderBy: suggestedCandidateOrderBy,
   });
 
   // Check if current user can edit this candidate profile

--- a/lib/liveElectionOrdering.ts
+++ b/lib/liveElectionOrdering.ts
@@ -1,0 +1,109 @@
+import { isElectionActive } from "@/lib/isElectionActive";
+
+export type CandidateElectionSummary = {
+  elections?: {
+    election: {
+      id: number;
+      city: string | null;
+      state: string;
+      date: string | Date;
+      position?: string | null;
+    } | null;
+  }[];
+};
+
+export type GroupedElectionWithDate = {
+  city: string | null;
+  state: string;
+  positions: string[];
+  date: string | Date;
+};
+
+export function getElectionLocationKey(
+  city: string | null | undefined,
+  state: string | undefined
+): string {
+  const normalizedCity = (city ?? "").trim().toLowerCase();
+  const normalizedState = (state ?? "").trim().toLowerCase();
+  return `${normalizedCity}|${normalizedState}`;
+}
+
+export function buildSuggestedElectionOrder(
+  suggestedCandidates: CandidateElectionSummary[],
+  { activeOnly = true }: { activeOnly?: boolean } = {}
+): string[] {
+  const seen = new Set<string>();
+  const order: string[] = [];
+
+  for (const candidate of suggestedCandidates) {
+    const links = candidate.elections ?? [];
+    for (const link of links) {
+      const election = link.election;
+      if (!election) continue;
+      if (activeOnly) {
+        const date = election.date ? new Date(election.date) : null;
+        if (!date || !isElectionActive(date)) continue;
+      }
+      const key = getElectionLocationKey(election.city ?? null, election.state);
+      if (!key.trim() || seen.has(key)) continue;
+      seen.add(key);
+      order.push(key);
+    }
+  }
+
+  return order;
+}
+
+export function orderLiveElectionsByPriority<T extends { city: string | null; state: string }>(
+  elections: T[],
+  prioritizedKeys: string[]
+): T[] {
+  if (elections.length === 0) {
+    return elections;
+  }
+
+  if (prioritizedKeys.length === 0) {
+    return shuffleArray(elections);
+  }
+
+  const priorityIndex = new Map<string, number>();
+  prioritizedKeys.forEach((key, index) => {
+    if (!priorityIndex.has(key)) {
+      priorityIndex.set(key, index);
+    }
+  });
+
+  const prioritized: T[] = [];
+  const remainder: T[] = [];
+
+  for (const election of elections) {
+    const key = getElectionLocationKey(election.city ?? null, election.state);
+    if (priorityIndex.has(key)) {
+      prioritized.push(election);
+    } else {
+      remainder.push(election);
+    }
+  }
+
+  prioritized.sort((a, b) => {
+    const keyA = getElectionLocationKey(a.city ?? null, a.state);
+    const keyB = getElectionLocationKey(b.city ?? null, b.state);
+    return (
+      (priorityIndex.get(keyA) ?? Number.MAX_SAFE_INTEGER) -
+      (priorityIndex.get(keyB) ?? Number.MAX_SAFE_INTEGER)
+    );
+  });
+
+  const shuffledRemainder = shuffleArray(remainder);
+
+  return [...prioritized, ...shuffledRemainder];
+}
+
+export function shuffleArray<T>(input: T[]): T[] {
+  const array = [...input];
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}

--- a/lib/suggestedCandidates.ts
+++ b/lib/suggestedCandidates.ts
@@ -1,0 +1,42 @@
+import type { Prisma } from "@prisma/client";
+
+const IMAGE_EXCLUSION_URLS = [
+  "/example-johnny.jpg",
+  "/johnny-lawnsign.png",
+];
+
+export function buildSuggestedCandidateWhere(
+  excludeCandidateId?: number
+): Prisma.CandidateWhereInput {
+  return {
+    hidden: false,
+    ...(typeof excludeCandidateId === "number"
+      ? { id: { not: excludeCandidateId } }
+      : {}),
+    elections: {
+      some: {
+        ContentBlock: {
+          some: {
+            type: "IMAGE",
+            imageUrl: {
+              notIn: IMAGE_EXCLUSION_URLS,
+              not: null,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+export const suggestedCandidateOrderBy: Prisma.CandidateOrderByWithRelationInput[] = [
+  { verified: "desc" },
+  { updatedAt: "desc" },
+  { id: "desc" },
+];
+
+export type SuggestedCandidateWhere = ReturnType<
+  typeof buildSuggestedCandidateWhere
+>;
+
+export const suggestedCandidateImageExclusionUrls = IMAGE_EXCLUSION_URLS;


### PR DESCRIPTION
## Summary
- centralize "Suggested Candidates" query filters and ordering
- expose a suggested candidates API that includes linked elections
- drive the live elections page and banner ordering from suggested candidate elections with randomized remainder

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e48dc62fa0832aad70608939da30a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added suggested candidates API.
  - Live Elections and banner now prioritize locations based on suggested candidates for more relevant results.
  - Candidate pages show improved suggested candidates.

- Refactor
  - Parallelized data fetching for elections and suggestions to reduce load times.
  - Improved grouping and ordering of elections by city/state with smarter de-duplication.

- Bug Fixes
  - More resilient error handling with fallbacks when suggestions fail, reducing user-visible errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->